### PR TITLE
This is needed when creating directories and initial root was a relat…

### DIFF
--- a/src/SftpAdapter.php
+++ b/src/SftpAdapter.php
@@ -142,6 +142,7 @@ class SftpAdapter extends AbstractFtpAdapter
         if (! $this->connection->chdir($root)) {
             throw new RuntimeException('Root is invalid or does not exist: '.$root);
         }
+        $this->root = $this->connection->pwd();
     }
 
     /**

--- a/tests/SftpAdapterTests.php
+++ b/tests/SftpAdapterTests.php
@@ -17,7 +17,7 @@ class SftpTests extends PHPUnit_Framework_TestCase
     public function adapterProvider()
     {
         $adapter = new Sftp(['username' => 'test', 'password' => 'test']);
-        $mock = Mockery::mock('phpseclib\Net\SFTP');
+        $mock = Mockery::mock('phpseclib\Net\SFTP')->makePartial();
         $mock->shouldReceive('__toString')->andReturn('Net_SFTP');
         $mock->shouldReceive('isConnected')->andReturn(true);
         $mock->shouldReceive('disconnect');


### PR DESCRIPTION
…ive path, else the root would be relative to the chdir'd path.
